### PR TITLE
Allow borrowed arguments in get_time_machine and get_forecast

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ extern crate itertools;
 extern crate reqwest;
 
 use std::vec::Vec;
+use std::borrow::Borrow;
 use std::option::Option;
 
 use itertools::join;
@@ -133,8 +134,9 @@ impl<'a> ApiClient<'a> {
     /// This function is a thin wrapper around
     /// `reqwest::Client.get(..)`, so it will return an error under the
     /// same conditions in which reqwest would.
-    pub fn get_forecast(self, request: ForecastRequest) -> ApiResult<Response> {
-        self.client.get(request.url)
+    pub fn get_forecast<'b, T>(&self, request: T) -> ApiResult<Response>
+        where T : Borrow<ForecastRequest<'b>> + Sized {
+        self.client.get(request.borrow().url.clone())
             .header(AcceptEncoding(vec![qitem(Encoding::Gzip)]))
             .send()
     }
@@ -148,8 +150,9 @@ impl<'a> ApiClient<'a> {
     /// This function is a thin wrapper around
     /// `reqwest::Client.get(..)`, so it will return an error under the
     /// same conditions in which reqwest would.
-    pub fn get_time_machine(self, request: TimeMachineRequest) -> ApiResult<Response> {
-        self.client.get(request.url)
+    pub fn get_time_machine<'b, T>(&self, request: T) -> ApiResult<Response>
+        where T : Borrow<TimeMachineRequest<'b>> + Sized {
+        self.client.get(request.borrow().url.clone())
             .header(AcceptEncoding(vec![qitem(Encoding::Gzip)]))
             .send()
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -151,6 +151,44 @@ fn test_get_forecast_request_full() {
 
 #[test]
 #[cfg(feature = "integration")]
+fn test_get_forecast_request_full_asref() {
+    let api_key = env!("FORECAST_API_KEY");
+
+    let reqwest_client = Client::builder()
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .build()
+        .unwrap();
+
+    let api_client = ApiClient::new(&reqwest_client);
+
+    let mut blocks = vec![ExcludeBlock::Alerts];
+
+    let forecast_request = ForecastRequestBuilder::new(api_key, LAT, LONG)
+        .exclude_block(ExcludeBlock::Flags)
+        .exclude_blocks(&mut blocks)
+        .extend(ExtendBy::Hourly)
+        .lang(Lang::Swedish)
+        .units(Units::SI)
+        .build();
+
+    let response = api_client.get_forecast(&forecast_request).unwrap();
+    response.headers();
+    let status = response.status();
+
+    assert_eq!(status, StatusCode::Ok);
+
+    let api_response: ApiResponse = serde_json::from_reader(response).unwrap();
+
+    assert_eq!(api_response.latitude, LAT);
+    assert_eq!(api_response.longitude, LONG);
+
+    // Use the following invocation to display the JSON response:
+    // FORECAST_API_KEY=$YOUR_FORECAST_API_KEY cargo test --features integration -- --nocapture
+    println!("{}", serde_json::to_string_pretty(&api_response).unwrap());
+}
+
+#[test]
+#[cfg(feature = "integration")]
 fn test_get_time_machine_request_default() {
     let api_key = env!("FORECAST_API_KEY");
 
@@ -204,6 +242,37 @@ fn test_get_time_machine_request_full() {
         .build();
 
     let response = api_client.get_time_machine(time_machine_request).unwrap();
+    let status = response.status();
+
+    assert_eq!(status, StatusCode::Ok);
+
+    let api_response: ApiResponse = serde_json::from_reader(response).unwrap();
+
+    assert_eq!(api_response.latitude, LAT);
+    assert_eq!(api_response.longitude, LONG);
+
+    // Use the following invocation to display the JSON response:
+    // FORECAST_API_KEY=$YOUR_FORECAST_API_KEY cargo test --features integration -- --nocapture
+    println!("{}", serde_json::to_string_pretty(&api_response).unwrap());
+}
+
+#[test]
+#[cfg(feature = "integration")]
+fn test_get_time_machine_request_default_asref() {
+    let api_key = env!("FORECAST_API_KEY");
+
+    let reqwest_client = Client::builder()
+        .timeout(Duration::from_secs(TIMEOUT_SECS))
+        .build()
+        .unwrap();
+
+    let api_client = ApiClient::new(&reqwest_client);
+
+    let time_machine_request = TimeMachineRequestBuilder::new(
+        api_key, LAT, LONG, TIME
+    ).build();
+
+    let response = api_client.get_time_machine(&time_machine_request).unwrap();
     let status = response.status();
 
     assert_eq!(status, StatusCode::Ok);


### PR DESCRIPTION
This shouldn't change the public API, but it should allow multiple requests to
be made with the same specification and client.