### PR TITLE
make builds work on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
-script: cargo test --features integration
+script: 
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then cargo test --features integration; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then cargo test; fi'
 notifications:
   email:
     - jesse.grillo@gmail.com


### PR DESCRIPTION
Travis PR builds fail for pull requests from a fork due to hidden environment variable security settings. With this config change we won't run integration tests for PR builds.