### PR TITLE
Upgrade to reqwest 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ integration = []
 serde = "1.0.*"
 serde_derive = "1.0.*"
 serde_json = "1.0.*"
-reqwest = "0.8.*"
+reqwest = "0.9.1"
 itertools = "0.7.*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,6 @@ use serde::ser::{Serialize, Serializer};
 use itertools::join;
 
 use reqwest::{Url, Result as ApiResult, Client, Response};
-use reqwest::header::{Encoding, AcceptEncoding, qitem};
 
 // constants
 
@@ -140,7 +139,7 @@ impl<'a> ApiClient<'a> {
     pub fn get_forecast<'b, T>(&self, request: T) -> ApiResult<Response>
         where T : Borrow<ForecastRequest<'b>> + Sized {
         self.client.get(request.borrow().url.clone())
-            .header(AcceptEncoding(vec![qitem(Encoding::Gzip)]))
+            .header("Accept-Encoding", "gzip")
             .send()
     }
 
@@ -156,7 +155,7 @@ impl<'a> ApiClient<'a> {
     pub fn get_time_machine<'b, T>(&self, request: T) -> ApiResult<Response>
         where T : Borrow<TimeMachineRequest<'b>> + Sized {
         self.client.get(request.borrow().url.clone())
-            .header(AcceptEncoding(vec![qitem(Encoding::Gzip)]))
+            .header("Accept-Encoding", "gzip")
             .send()
     }
 }


### PR DESCRIPTION
This library will stop compiling on machines which receive `openssl` 1.1.1 if `reqwest` is left at 0.8 (already happening on arch)